### PR TITLE
Annotation update

### DIFF
--- a/AddRomanLSST.ipynb
+++ b/AddRomanLSST.ipynb
@@ -5,16 +5,7 @@
    "execution_count": 2,
    "id": "d462e01a-347b-4148-9412-0e1faa264bb7",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/yse2/.conda/envs/deepdisc/lib/python3.9/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import json\n",
     "import copy\n",
@@ -24,7 +15,7 @@
     "from detectron2.data import detection_utils as utils\n",
     "import detectron2.data.transforms as T\n",
     "from detectron2.data import MetadataCatalog, DatasetCatalog\n",
-    "from deepdisc.data_format.image_readers import DC2ImageReader, HSCImageReader, RomanImageReader\n",
+    "from deepdisc.data_format.image_readers import DC2ImageReader, HSCImageReader#, RomanImageReader\n",
     "from PIL import Image\n",
     "import matplotlib.pyplot as plt\n",
     "import matplotlib.colors as colors\n",
@@ -1223,13 +1214,76 @@
     "# plt.axis('off')\n",
     "plt.scatter(truth_cat.new_x.values,truth_cat.new_y.values,s=1, color='k')"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d38480de-a323-42b7-9c92-132baa3e3728",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "757595c9-e006-4782-890d-303494cdfaad",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "76bee85f-ca48-435d-bb51-e87f2a1ade87",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "a3e371fe-4f74-4f7b-83f9-3d0569259d99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "im = np.load('/home/shared/hsc/roman_lsst/lsst_data/truthc-ups/dc2_51.53_-40.0/full_c103_51.53_-40.0.npy')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "25f6df3a-9808-4eef-8fef-2478e5a3e7d2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(10, 512, 512)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "im.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3edf4512-d3a3-4d79-958e-358bc9debe36",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:.conda-deepdisc]",
+   "display_name": "Python [conda env:.conda-ddrailnv]",
    "language": "python",
-   "name": "conda-env-.conda-deepdisc-py"
+   "name": "conda-env-.conda-ddrailnv-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1241,7 +1295,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.15"
+   "version": "3.9.18"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Annotations are now made by
1. Simulating the noiseless image
2. Convolving with a PSF 
3. Thresholding based on the fiducial background*effective PSF area
4. Dilating by the PSF size
5. Additionally, Any annotation smaller than 12 pixels is rejected